### PR TITLE
Make FutureImpl Send

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-- nightly-2019-01-08
+- nightly-2019-01-11
 - nightly
 
 os:

--- a/embrio-async/dehygiene/src/lib.rs
+++ b/embrio-async/dehygiene/src/lib.rs
@@ -19,7 +19,7 @@ pub fn await(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             // safe for reasons explained in the embrio-async safety notes.
             let polled = unsafe {
                 let pin = ::core::pin::Pin::new_unchecked(&mut pinned);
-                ::core::future::Future::poll(pin, &**#arg)
+                ::core::future::Future::poll(pin, #arg.get_waker())
             };
             if let ::core::task::Poll::Ready(x) = polled {
                 break x;

--- a/embrio-async/src/lib.rs
+++ b/embrio-async/src/lib.rs
@@ -73,6 +73,13 @@ where
     }
 }
 
+unsafe impl<F, G> Send for FutureImpl<F, G>
+where
+    F: Send + FnOnce(*const *const LocalWaker) -> G,
+    G: Generator<Yield = ()>,
+{
+}
+
 pub unsafe fn make_future<F, G>(f: F) -> impl Future<Output = G::Return>
 where
     F: FnOnce(*const *const LocalWaker) -> G,

--- a/embrio-async/src/lib.rs
+++ b/embrio-async/src/lib.rs
@@ -90,7 +90,7 @@ pub struct UnsafeWakeRef(*const *const LocalWaker);
 impl UnsafeWakeRef {
     /// Get a reference to the wrapped waker
     ///
-    /// This must only be called from the `await!`
+    /// This must only be called from the `await!` macro within the
     /// `make_future` function, which will in turn only be run when the
     /// `FutureImpl` has been observed to be in a `Pin`, guaranteeing that the
     /// outer `*const` remains valid.


### PR DESCRIPTION
By the same logic as stated in the `poll` comment, `Send` should be safe to implement for `FutureImpl`.

The `local_waker` pointer won't be used until the `FutureImpl` is in a `Pin`, at which point, it can neither be moved nor sent to another thread, so the `Send` impl is only relevant for the time before the future begins to be polled.