### PR TITLE
Support async fn's

### DIFF
--- a/embrio-async/dehygiene/src/lib.rs
+++ b/embrio-async/dehygiene/src/lib.rs
@@ -5,6 +5,8 @@ extern crate proc_macro;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 
+use syn::{parse_macro_input, FnArg, FnDecl, ItemFn, ReturnType, Type};
+
 #[proc_macro]
 pub fn await(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input: TokenStream = input.into();
@@ -86,6 +88,104 @@ pub fn async_stream_block(
                     #input
                 }
             })
+        }
+    })
+    .into()
+}
+
+#[proc_macro_attribute]
+pub fn async_fn(
+    attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    assert!(attr.is_empty(), "async_fn attribute takes no arguments");
+    async_fn_impl(parse_macro_input!(body)).into()
+}
+
+fn async_fn_impl(item: ItemFn) -> TokenStream {
+    let ItemFn {
+        attrs,
+        vis,
+        constness,
+        unsafety,
+        asyncness,
+        abi,
+        ident,
+        decl,
+        block,
+    } = item;
+
+    let FnDecl {
+        generics,
+        inputs,
+        output,
+        ..
+    } = *decl;
+
+    // add bound to existing lifetimes
+    let lifetime_defs = generics.lifetimes().map(|lt| {
+        if lt.colon_token.is_some() {
+            quote! {
+                #lt + 'future
+            }
+        } else {
+            quote! {
+                #lt : 'future
+            }
+        }
+    });
+
+    // add lifetime bound to existing generics
+    let type_params = generics.type_params().map(|tp| {
+        if tp.colon_token.is_some() {
+            quote! {
+                #tp + 'future
+            }
+        } else {
+            quote! {
+                #tp: 'future
+            }
+        }
+    });
+
+    // add lifetime bounds to impl Trait args
+    let inputs = inputs.into_iter().map(|input| {
+        match &input {
+            FnArg::Captured(binding) => match &binding.ty {
+                Type::ImplTrait(implty) => {
+                    let pat = &binding.pat;
+                    return quote! {
+                        #pat : #implty + 'future
+                    };
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+        quote! {
+            #input
+        }
+    });
+
+    let where_clause = &generics.where_clause;
+
+    let lifetimes = generics.lifetimes().map(|lt| lt.lifetime.clone());
+    let output_type = match output {
+        ReturnType::Default => quote! {
+            impl Future<Output = ()> #(+ ::embrio_async::Captures<#lifetimes>)* + 'future
+        },
+        ReturnType::Type(_, ty) => {
+            quote! { impl Future<Output = #ty> #(+ ::embrio_async::Captures<#lifetimes>)* + 'future }
+        }
+    };
+
+    (quote! {
+        #(#attrs)*
+        #vis #constness #unsafety #asyncness #abi
+        fn #ident <'future #(, #lifetime_defs)* #(, #type_params)*> (#(#inputs),*) -> #output_type
+        #where_clause
+        {
+            ::embrio_async::async_block! #block
         }
     })
     .into()

--- a/embrio-async/src/lib.rs
+++ b/embrio-async/src/lib.rs
@@ -23,7 +23,14 @@ use core::{
 };
 use futures_core::stream::Stream;
 
-pub use embrio_async_dehygiene::{async_block, async_stream_block, await};
+pub use embrio_async_dehygiene::{
+    async_block, async_fn, async_stream_block, await,
+};
+
+#[doc(hidden)]
+/// Dummy trait for capturing additional lifetime bounds on `impl Trait`s
+pub trait Captures<'a> {}
+impl<'a, T: ?Sized> Captures<'a> for T {}
 
 unsafe fn loosen_context_lifetime<'a>(
     context: &'a mut task::Context<'_>,

--- a/embrio-async/tests/smoke.rs
+++ b/embrio-async/tests/smoke.rs
@@ -7,7 +7,9 @@
     proc_macro_hygiene
 )]
 
-use embrio_async::{async_block, async_stream_block, await};
+use core::future::Future;
+
+use embrio_async::{async_block, async_fn, async_stream_block, await};
 use ergo_pin::ergo_pin;
 use futures::{executor::block_on, stream::StreamExt};
 use futures_test::future::FutureTestExt;
@@ -30,4 +32,45 @@ fn smoke_stream() {
     assert_eq!(block_on(stream.next()), Some(5));
     assert_eq!(block_on(stream.next()), Some(6));
     assert_eq!(block_on(stream.next()), None);
+}
+
+#[test]
+fn smoke_async_block() {
+    let f = async_block! {
+        5usize
+    };
+
+    let f2 = async_block! {
+        await!(f)
+    };
+
+    assert_eq!(block_on(f2), 5);
+}
+
+#[derive(Eq, PartialEq, Debug)]
+enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+
+#[async_fn]
+fn a_number_and_string<'a, 'b>(
+    n: &'a usize,
+    s: &'b str,
+) -> Either<usize, &'b str> {
+    if *n % 2 == 0 {
+        Either::Left(*n)
+    } else {
+        Either::Right(s)
+    }
+}
+
+#[async_fn]
+fn a_wait_thing() -> Either<usize, &'static str> {
+    await!(a_number_and_string(&5, "Hello, world!"))
+}
+
+#[test]
+fn smoke_async_fn() {
+    assert_eq!(block_on(a_wait_thing()), Either::Right("Hello, world!"));
 }

--- a/embrio-async/tests/smoke.rs
+++ b/embrio-async/tests/smoke.rs
@@ -34,19 +34,6 @@ fn smoke_stream() {
     assert_eq!(block_on(stream.next()), None);
 }
 
-#[test]
-fn smoke_async_block() {
-    let f = async_block! {
-        5usize
-    };
-
-    let f2 = async_block! {
-        await!(f)
-    };
-
-    assert_eq!(block_on(f2), 5);
-}
-
 #[derive(Eq, PartialEq, Debug)]
 enum Either<L, R> {
     Left(L),
@@ -54,10 +41,7 @@ enum Either<L, R> {
 }
 
 #[async_fn]
-fn a_number_and_string<'a, 'b>(
-    n: &'a usize,
-    s: &'b str,
-) -> Either<usize, &'b str> {
+fn a_number_and_string<'a>(n: &usize, s: &'a str) -> Either<usize, &'a str> {
     if *n % 2 == 0 {
         Either::Left(*n)
     } else {
@@ -68,6 +52,11 @@ fn a_number_and_string<'a, 'b>(
 #[async_fn]
 fn a_wait_thing() -> Either<usize, &'static str> {
     await!(a_number_and_string(&5, "Hello, world!"))
+}
+
+#[async_fn]
+fn anonymous_lifetime(f: &mut core::fmt::Formatter<'_>) {
+    let _ = write!(f, "Hello, world!");
 }
 
 #[test]


### PR DESCRIPTION
Support the async_fn attribute by transforming the signature and internally calling the existing async_block macro.
    
Supports multiple lifetimes by adding a `'future` lifetime and using dummy `Captures<'_>` trait bounds on the returned future.

I'm somewhat of a novice when it comes to writing proc macros, so I'm bound to have missed something :stuck_out_tongue: 