### PR TITLE
Rewrite async/await in their entirety.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-- nightly-2019-04-25
+- nightly-2019-05-11
 - nightly
 
 os:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [
   "embrio",
   "embrio-async",
-  "embrio-async/dehygiene",
+  "embrio-async/macros",
   "embrio-core",
   "embrio-executor",
   "embrio-native",

--- a/embrio-async/Cargo.toml
+++ b/embrio-async/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["Wim Looman <wim@nemo157.com>"]
 edition = "2018"
 
 [dependencies]
-embrio-async-dehygiene = { path = "dehygiene" }
-futures-core-preview = { version = "0.3.0-alpha.14", default-features = false }
+embrio-async-macros = { path = "macros" }
+futures-core-preview = { version = "0.3.0-alpha.16", default-features = false }
 
 [dev-dependencies]
-futures-preview = "0.3.0-alpha.14"
+futures-preview = "0.3.0-alpha.16"
 pin-utils = "0.1.0-alpha.4"
 ergo-pin = { git = "https://github.com/Nemo157/ergo-pin-rs" }
-futures-test-preview = "0.3.0-alpha.15"
+futures-test-preview = "0.3.0-alpha.16"

--- a/embrio-async/macros/Cargo.toml
+++ b/embrio-async/macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "embrio-async-dehygiene"
+name = "embrio-async-macros"
 version = "0.1.0"
 authors = ["Wim Looman <wim@nemo157.com>"]
 edition = "2018"
@@ -10,4 +10,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "0.4.24"
 quote = "0.6.10"
-syn = { version = "0.15.26", features = ["full", "visit-mut", "parsing"] }
+syn = { version = "0.15.26", features = ["full", "visit", "visit-mut", "parsing"] }

--- a/embrio-async/macros/src/lib.rs
+++ b/embrio-async/macros/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(async_await)]
-
 extern crate proc_macro;
 
 #[macro_use]
@@ -9,16 +7,14 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 
 use syn::{
-    parse_macro_input, visit_mut::VisitMut, Block, Generics, ItemFn, Lifetime,
-    LifetimeDef, ReturnType, TypeImplTrait, TypeParam, TypeParamBound,
-    TypeReference,
+    parse_macro_input, visit::Visit, visit_mut::VisitMut, Block, Expr,
+    ExprField, ExprYield, Generics, ItemFn, Lifetime, LifetimeDef, Member,
+    ReturnType, TypeImplTrait, TypeParam, TypeParamBound, TypeReference,
 };
 
-#[proc_macro]
-pub fn await(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input: TokenStream = input.into();
+fn await_impl(input: &Expr) -> Expr {
     let arg = Ident::new("_embrio_async_context_argument", Span::call_site());
-    quote!({
+    let expr = quote!({
         let mut pinned = #input;
         loop {
             // Safety: We trust users to only call this from within an
@@ -35,35 +31,33 @@ pub fn await(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             }
             yield ::core::task::Poll::Pending;
         }
-    })
-    .into()
+    });
+    syn::parse2(expr).unwrap()
 }
 
-#[proc_macro]
-pub fn async_block(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input: TokenStream = input.into();
+fn async_block(expr_async: &syn::ExprAsync) -> Expr {
+    let block = &expr_async.block;
+    let mv = &expr_async.capture;
     let arg = Ident::new("_embrio_async_context_argument", Span::call_site());
-    quote!({
+    let tokens = quote!({
         // Safety: We trust users not to come here, see that argument name we
         // generated above and use that in their code to break our other safety
         // guarantees. Our use of it in await! is safe because of reasons
         // probably described in the embrio-async safety notes.
         unsafe {
-            ::embrio_async::make_future(move |mut #arg| {
+            ::embrio_async::make_future(#mv |mut #arg| {
                 static move || {
                     if false { yield ::core::task::Poll::Pending }
-                    #input
+                    #block
                 }
             })
         }
-    })
-    .into()
+    });
+
+    syn::parse2(tokens).unwrap()
 }
 
-#[proc_macro]
-pub fn async_stream_block(
-    input: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
+fn async_stream_block(expr_async: &mut syn::ExprAsync) -> Expr {
     struct ReplaceYields;
 
     impl syn::visit_mut::VisitMut for ReplaceYields {
@@ -77,31 +71,39 @@ pub fn async_stream_block(
                 syn::parse2(quote!(::core::task::Poll::Ready(#expr))).unwrap(),
             ));
         }
+        fn visit_expr_mut(&mut self, i: &mut Expr) {
+            // Don't descend into closures
+            if let Expr::Closure(_) = i {
+                return;
+            }
+            syn::visit_mut::visit_expr_mut(self, i);
+        }
     }
 
-    let input: TokenStream = input.into();
-    let mut input: syn::Block = syn::parse2(quote!({ #input })).unwrap();
-    syn::visit_mut::VisitMut::visit_block_mut(&mut ReplaceYields, &mut input);
+    let mut block = &mut expr_async.block;
+    let capture = &expr_async.capture;
+    syn::visit_mut::VisitMut::visit_block_mut(&mut ReplaceYields, &mut block);
     let arg = Ident::new("_embrio_async_context_argument", Span::call_site());
-    quote!({
+    let stream = quote!({
         // Safety: We trust users not to come here, see that argument name we
         // generated above and use that in their code to break our other safety
         // guarantees. Our use of it in await! is safe because of reasons
         // probably described in the embrio-async safety notes.
         unsafe {
-            ::embrio_async::make_stream(move |mut #arg| {
+            ::embrio_async::make_stream(#capture |mut #arg| {
                 static move || {
                     if false { yield ::core::task::Poll::Pending }
-                    #input
+                    #block
                 }
             })
         }
-    })
-    .into()
+    });
+
+    syn::parse2(stream).unwrap()
 }
 
 #[proc_macro_attribute]
-pub fn async_fn(
+pub fn embrio_async(
     attr: proc_macro::TokenStream,
     body: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
@@ -110,12 +112,90 @@ pub fn async_fn(
 }
 
 fn async_fn_impl(mut item: ItemFn) -> TokenStream {
-    syn::visit_mut::visit_item_fn_mut(
-        &mut AsyncFnTransform::default(),
-        &mut item,
-    );
+    if item.asyncness.is_some() {
+        item.asyncness = None;
+        syn::visit_mut::visit_item_fn_mut(
+            &mut AsyncFnTransform::default(),
+            &mut item,
+        );
+    }
+
+    syn::visit_mut::visit_block_mut(&mut AsyncBlockTransform, &mut item.block);
+    syn::visit_mut::visit_block_mut(&mut ExpandAwait, &mut item.block);
 
     quote!(#item)
+}
+
+struct ExpandAwait;
+
+impl syn::visit_mut::VisitMut for ExpandAwait {
+    fn visit_expr_mut(&mut self, node: &mut syn::Expr) {
+        syn::visit_mut::visit_expr_mut(self, node);
+        let base = match node {
+            syn::Expr::Field(ExprField { member, base, .. }) => {
+                let member = if let Member::Named(m) = member {
+                    m
+                } else {
+                    return;
+                };
+
+                if member == "await" {
+                    &*base
+                } else {
+                    return;
+                }
+            }
+            _ => return,
+        };
+
+        *node = await_impl(base);
+    }
+}
+
+#[derive(Default)]
+struct AsyncBlockTransform;
+
+impl VisitMut for AsyncBlockTransform {
+    fn visit_expr_mut(&mut self, i: &mut Expr) {
+        syn::visit_mut::visit_expr_mut(self, i);
+        let fut = match i {
+            Expr::Async(expr_async) => {
+                if contains_yield(&expr_async.block) {
+                    async_stream_block(expr_async)
+                } else {
+                    async_block(&expr_async)
+                }
+            }
+            _ => {
+                return;
+            }
+        };
+
+        *i = fut;
+    }
+}
+
+fn contains_yield(block: &Block) -> bool {
+    struct ContainsYield(bool);
+
+    impl<'a> Visit<'a> for ContainsYield {
+        fn visit_expr_yield(&mut self, i: &'a ExprYield) {
+            syn::visit::visit_expr_yield(self, i);
+            self.0 = true;
+        }
+
+        fn visit_expr(&mut self, i: &'a Expr) {
+            // Don't descend into closures
+            if let Expr::Closure(_) = i {
+                return;
+            }
+            syn::visit::visit_expr(self, i);
+        }
+    }
+
+    let mut visitor = ContainsYield(false);
+    syn::visit::visit_block(&mut visitor, block);
+    visitor.0
 }
 
 #[derive(Default)]
@@ -170,10 +250,7 @@ impl VisitMut for AsyncFnTransform {
             .insert(0, LifetimeDef::new(future_lifetime()).into());
     }
     fn visit_block_mut(&mut self, i: &mut Block) {
-        let async_block = quote!({
-            ::embrio_async::async_block! #i
-        });
-        *i = syn::parse2(async_block).expect("parsed block");
+        *i = syn::parse_quote!({ async move #i });
     }
     fn visit_return_type_mut(&mut self, i: &mut ReturnType) {
         let lifetimes = &self.original_lifetimes;

--- a/embrio-async/macros/src/lib.rs
+++ b/embrio-async/macros/src/lib.rs
@@ -132,19 +132,11 @@ impl syn::visit_mut::VisitMut for ExpandAwait {
     fn visit_expr_mut(&mut self, node: &mut syn::Expr) {
         syn::visit_mut::visit_expr_mut(self, node);
         let base = match node {
-            syn::Expr::Field(ExprField { member, base, .. }) => {
-                let member = if let Member::Named(m) = member {
-                    m
-                } else {
-                    return;
-                };
-
-                if member == "await" {
-                    &*base
-                } else {
-                    return;
-                }
-            }
+            syn::Expr::Field(ExprField {
+                member: Member::Named(member),
+                base,
+                ..
+            }) if member == "await" => &*base,
             _ => return,
         };
 
@@ -179,8 +171,7 @@ fn contains_yield(block: &Block) -> bool {
     struct ContainsYield(bool);
 
     impl<'a> Visit<'a> for ContainsYield {
-        fn visit_expr_yield(&mut self, i: &'a ExprYield) {
-            syn::visit::visit_expr_yield(self, i);
+        fn visit_expr_yield(&mut self, _: &'a ExprYield) {
             self.0 = true;
         }
 

--- a/embrio-async/src/lib.rs
+++ b/embrio-async/src/lib.rs
@@ -1,12 +1,5 @@
 #![no_std]
-#![feature(
-    arbitrary_self_types,
-    async_await,
-    exhaustive_patterns,
-    generator_trait,
-    generators,
-    never_type
-)]
+#![feature(exhaustive_patterns, generator_trait, generators, never_type)]
 // TODO: Figure out to hygienically have a loop between proc-macro and library
 // crates
 //! This crate must not be renamed or facaded because it's referred to by name
@@ -23,9 +16,7 @@ use core::{
 };
 use futures_core::stream::Stream;
 
-pub use embrio_async_dehygiene::{
-    async_block, async_fn, async_stream_block, await,
-};
+pub use embrio_async_macros::embrio_async;
 
 #[doc(hidden)]
 /// Dummy trait for capturing additional lifetime bounds on `impl Trait`s

--- a/embrio-async/tests/no-prelude-leak.rs
+++ b/embrio-async/tests/no-prelude-leak.rs
@@ -1,48 +1,44 @@
+#![no_std]
 #![no_implicit_prelude]
-#![feature(
-    arbitrary_self_types,
-    async_await,
-    await_macro,
-    generator_trait,
-    generators,
-    proc_macro_hygiene
-)]
+#![feature(generators, core_panic_info)]
+
+extern crate embrio_async;
+
+use embrio_async::embrio_async;
 
 // This is using no_implicit_prelude to test that the macros don't accidentally
 // refer directly to any paths from core's implicitly injected prelude and
 // instead everything is going through the internal re-export.
 
+#[embrio_async]
 #[test]
 fn smoke() {
-    let future = async {
-        ::std::await!(::embrio_async::async_block! {
-            ::embrio_async::await!(async { 5 })
-        })
-    };
+    let future = async { async { async { 5 }.await }.await };
     {
-        use ::std::panic;
-        ::std::assert_eq!(::futures::executor::block_on(future), 5);
+        use ::core::panic;
+        ::core::assert_eq!(::futures::executor::block_on(future), 5);
     }
 }
 
+#[embrio_async]
 #[test]
 fn smoke_stream() {
     let future = async {
-        let stream = ::embrio_async::async_stream_block! {
-            yield ::embrio_async::await!(async { 5 });
-            yield ::embrio_async::await!(async { 6 });
+        let stream = async {
+            yield async { 5usize }.await;
+            yield async { 6usize }.await;
         };
         ::pin_utils::pin_mut!(stream);
-        let mut sum = 0;
-        while let ::std::option::Option::Some(val) =
-            ::std::await!(::futures::stream::StreamExt::next(&mut stream))
+        let mut sum = 0usize;
+        while let ::core::option::Option::Some(val) =
+            ::futures::stream::StreamExt::next(&mut stream).await
         {
             sum += val;
         }
         sum
     };
     {
-        use ::std::panic;
-        ::std::assert_eq!(::futures::executor::block_on(future), 11);
+        use ::core::panic;
+        ::core::assert_eq!(::futures::executor::block_on(future), 11);
     }
 }


### PR DESCRIPTION
Pretty big change to the way `embrio-async` does things. Rather than using special macros for async blocks/await, this instead allows users to use the regular syntax for async/await and rewrites things in the `embrio` way.  They just have to tag functions using async/await with `#[embrio_async]` to enable the rewrites.

This allows for some nice things like proper move/borrow capture semantics on async blocks and removes the need for the proc macro hygiene feature. In fact, the only features that downstream crates need enable is `generators`.

Stream blocks are differentiated from regular async blocks via the presence of `yields`, much the same way that generators are differentiated from regular closures.

I'm not entirely sure how this will impact the sink block PR since it has some special syntax/implicit input item.