### PR TITLE
Async transform fixes for bare `fn` and `&self`

### DIFF
--- a/embrio-async/macros/src/lib.rs
+++ b/embrio-async/macros/src/lib.rs
@@ -7,9 +7,10 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 
 use syn::{
-    parse_macro_input, visit::Visit, visit_mut::VisitMut, Block, Expr,
-    ExprField, ExprYield, Generics, ItemFn, Lifetime, LifetimeDef, Member,
-    ReturnType, TypeImplTrait, TypeParam, TypeParamBound, TypeReference,
+    parse_macro_input, visit::Visit, visit_mut::VisitMut, ArgSelfRef, Block,
+    Expr, ExprField, ExprYield, Generics, ItemFn, Lifetime, LifetimeDef,
+    Member, ReturnType, TypeBareFn, TypeImplTrait, TypeParam, TypeParamBound,
+    TypeReference,
 };
 
 fn await_impl(input: &Expr) -> Expr {
@@ -206,6 +207,12 @@ impl VisitMut for AsyncFnTransform {
         }
         self.visit_type_mut(&mut *i.elem);
     }
+    fn visit_arg_self_ref_mut(&mut self, i: &mut ArgSelfRef) {
+        if i.lifetime.is_none() {
+            i.lifetime = future_lifetime().into();
+        }
+    }
+    fn visit_type_bare_fn_mut(&mut self, _i: &mut TypeBareFn) {}
     fn visit_type_impl_trait_mut(&mut self, i: &mut TypeImplTrait) {
         for bound in i.bounds.iter_mut() {
             self.visit_type_param_bound_mut(bound);

--- a/embrio-async/tests/smoke.rs
+++ b/embrio-async/tests/smoke.rs
@@ -69,3 +69,21 @@ async fn anonymous_lifetime(f: &mut core::fmt::Formatter<'_>) {
 fn smoke_async_fn() {
     assert_eq!(block_on(a_wait_thing()), Either::Right("Hello, world!"));
 }
+
+#[allow(dead_code)]
+struct Foo(usize);
+
+impl Foo {
+    #[embrio_async]
+    async fn bar(&self) -> &usize {
+        &self.0
+    }
+    #[embrio_async]
+    async fn baz(&mut self) -> &usize {
+        &self.0
+    }
+    #[embrio_async]
+    async fn spam(&mut self, f: fn(&mut usize)) {
+        f(&mut self.0)
+    }
+}


### PR DESCRIPTION
@Nemo157 Are there ever cases where either bare `fn` arguments or return types will need to be visited by the async transform? I was seeing the default return type getting erroneously turned into `-> impl Future` which is definitely wrong, but I'm not sure if the argument/return types need to have the future lifetime applied. My gut says "no" and that we're fine skipping bare fn's altogether, but I thought I'd double-check.