### PR TITLE
export embrio::io::BufRead

### DIFF
--- a/embrio/src/lib.rs
+++ b/embrio/src/lib.rs
@@ -22,7 +22,7 @@ pub mod timer {
 }
 
 pub mod io {
-    pub use embrio_core::io::{void, Cursor, Read, Write};
+    pub use embrio_core::io::{void, BufRead, Cursor, Read, Write};
     pub use embrio_util::io::{
         close, flush, read_exact, read_until, write_all, BufReader,
     };


### PR DESCRIPTION
It seemed to be missing given that some of the util::io functions use it.