### PR TITLE
Update cortex-m and nrf51

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 script:
 - cargo test --all --exclude embrio-nrf51 --exclude pca10031
 - cargo build --target thumbv6m-none-eabi -p embrio-executor -p embrio-nrf51
-- cargo build --target thumbv6m-none-eabi -p pca10031 --examples
+- (cd examples/pca10031 && cargo build --target thumbv6m-none-eabi -p pca10031 --examples)
 - cargo build --target thumbv7m-none-eabi -p embrio-executor
 
 matrix:

--- a/embrio-nrf51/Cargo.toml
+++ b/embrio-nrf51/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Wim Looman <wim@nemo157.com>"]
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.5.8"
-nrf51 = "0.5.0"
+cortex-m = "0.6.1"
+nrf51 = "0.6.0"
 
 [dependencies.embrio-core]
 path = "../embrio-core"

--- a/embrio-nrf51/src/lib.rs
+++ b/embrio-nrf51/src/lib.rs
@@ -28,19 +28,15 @@ pub struct EmbrioNrf51<'b> {
 }
 
 impl<'b> EmbrioNrf51<'b> {
-    pub fn new(
-        cortex_m: &'b mut cortex_m::Peripherals,
-        nrf51: &'b mut nrf51::Peripherals,
-    ) -> EmbrioNrf51<'b> {
+    pub fn new(nrf51: &'b mut nrf51::Peripherals) -> EmbrioNrf51<'b> {
         let pins = Pins::new(&mut nrf51.GPIO);
-        let uart = Uart::new(&mut nrf51.UART0, &mut cortex_m.NVIC);
+        let uart = Uart::new(&mut nrf51.UART0);
 
         EmbrioNrf51 { pins, uart }
     }
 
     pub fn take() -> Option<EmbrioNrf51<'static>> {
         struct StaticPeripherals {
-            cortex_m: cortex_m::Peripherals,
             nrf51: nrf51::Peripherals,
         }
 
@@ -60,7 +56,6 @@ impl<'b> EmbrioNrf51<'b> {
         });
 
         free(|c| {
-            let cortex_m = cortex_m::Peripherals::take()?;
             let nrf51 = nrf51::Peripherals::take()?;
 
             let context = CONTEXT.borrow(c);
@@ -79,13 +74,12 @@ impl<'b> EmbrioNrf51<'b> {
             // once
             let peripherals = unsafe { &mut *context.peripherals.get() };
 
-            peripherals.replace(StaticPeripherals { cortex_m, nrf51 });
+            peripherals.replace(StaticPeripherals { nrf51 });
 
             let peripherals = peripherals.as_mut().unwrap();
-            let cortex_m = &mut peripherals.cortex_m;
             let nrf51 = &mut peripherals.nrf51;
 
-            Some(EmbrioNrf51::new(cortex_m, nrf51))
+            Some(EmbrioNrf51::new(nrf51))
         })
     }
 }

--- a/embrio-nrf51/src/lib.rs
+++ b/embrio-nrf51/src/lib.rs
@@ -90,20 +90,17 @@ impl<'b> EmbrioNrf51<'b> {
     }
 }
 
-/// This **MUST** be called in any binary that depends on this crate, for some
-/// reason linking the interrupt handlers in when they're defined in a
-/// dependency doesn't work.
-#[macro_export]
-macro_rules! interrupts {
-    () => {
-        $crate::interrupt!(UART0, $crate::uart::Uart::interrupt);
-        $crate::interrupt!(
-            TIMER0,
-            $crate::timer::Timer::<nrf51::TIMER0>::interrupt
-        );
-        $crate::interrupt!(
-            TIMER1,
-            $crate::timer::Timer::<nrf51::TIMER1>::interrupt
-        );
-    };
+#[interrupt]
+fn UART0() {
+    uart::Uart::interrupt()
+}
+
+#[interrupt]
+fn TIMER0() {
+    timer::Timer::<nrf51::TIMER0>::interrupt()
+}
+
+#[interrupt]
+fn TIMER1() {
+    timer::Timer::<nrf51::TIMER1>::interrupt()
 }

--- a/embrio-nrf51/src/timer/timer0.rs
+++ b/embrio-nrf51/src/timer/timer0.rs
@@ -19,13 +19,13 @@ static TIMER0_WAKER: Mutex<RefCell<Option<Waker>>> =
     Mutex::new(RefCell::new(None));
 
 impl Timer<TIMER0> {
-    pub fn timer0(timer: TIMER0, nvic: &mut NVIC) -> Timer<TIMER0> {
+    pub fn timer0(timer: TIMER0) -> Timer<TIMER0> {
         // 32bits @ 1MHz == max delay of ~1 hour 11 minutes
         timer.bitmode.write(|w| w.bitmode()._32bit());
         timer.prescaler.write(|w| unsafe { w.prescaler().bits(4) });
         timer.shorts.write(|w| w.compare0_clear().enabled());
 
-        nvic.enable(Interrupt::TIMER0);
+        unsafe { NVIC::unmask(Interrupt::TIMER0) };
 
         Timer(timer)
     }

--- a/embrio-nrf51/src/timer/timer1.rs
+++ b/embrio-nrf51/src/timer/timer1.rs
@@ -19,13 +19,13 @@ static TIMER1_WAKER: Mutex<RefCell<Option<Waker>>> =
     Mutex::new(RefCell::new(None));
 
 impl Timer<TIMER1> {
-    pub fn timer1(timer: TIMER1, nvic: &mut NVIC) -> Timer<TIMER1> {
+    pub fn timer1(timer: TIMER1) -> Timer<TIMER1> {
         // 32bits @ 1MHz == max delay of ~1 hour 11 minutes
         timer.bitmode.write(|w| w.bitmode()._32bit());
         timer.prescaler.write(|w| unsafe { w.prescaler().bits(4) });
         timer.shorts.write(|w| w.compare0_clear().enabled());
 
-        nvic.enable(Interrupt::TIMER1);
+        unsafe { NVIC::unmask(Interrupt::TIMER1) };
 
         Timer(timer)
     }

--- a/examples/pca10031/Cargo.toml
+++ b/examples/pca10031/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 
 [dependencies]
 hello = { path = "../apps/hello" }
-cortex-m-rt = { version = "0.6.1" }
-nrf51 = { version = "0.5.0", features = ["rt"] }
+cortex-m-rt = { version = "0.6.10" }
+nrf51 = { version = "0.6.0", features = ["rt"] }
 embrio = { path = "../../embrio" }
 embrio-nrf51 = { path = "../../embrio-nrf51" }
 panic-abort = { version = "0.3.1" }

--- a/examples/pca10031/examples/hello.rs
+++ b/examples/pca10031/examples/hello.rs
@@ -5,7 +5,7 @@
 use {nrf51 as _, panic_abort as _};
 
 use cortex_m_rt::{entry, exception, ExceptionFrame};
-use embrio_nrf51::{interrupts, uart::BAUDRATEW, EmbrioNrf51};
+use embrio_nrf51::{uart::BAUDRATEW, EmbrioNrf51};
 
 #[entry]
 fn main() -> ! {
@@ -29,5 +29,3 @@ fn HardFault(ef: &ExceptionFrame) -> ! {
 fn DefaultHandler(irqn: i16) {
     panic!("Unhandled exception (IRQn = {})", irqn);
 }
-
-interrupts!();


### PR DESCRIPTION
- Building the pca10031 example without changing cwd results in an empty binary because cargo doesn't implicitly pull in the rustflags from .cargo/config when using `-p` in a workspace.
- The interrupt macro hack no longer seems to be necessary.