### PR TITLE
async generator changes

### DIFF
--- a/embrio-async/macros/src/lib.rs
+++ b/embrio-async/macros/src/lib.rs
@@ -327,10 +327,10 @@ impl VisitMut for AsyncFnTransform {
         let lifetimes = &self.original_lifetimes;
         *i = syn::parse2(match i {
             ReturnType::Default => quote! {
-                -> impl ::core::future::Future<Output = ()> #(+ ::embrio_async::Captures<#lifetimes>)* + 'future
+                -> impl ::core::future::Future<Output = ()> #(+ ::embrio_async::Captures<#lifetimes>)* + ::embrio_async::PinnableFuture<FutureOutput = ()> + 'future
             },
             ReturnType::Type(_, ty) => quote! {
-                -> impl ::core::future::Future<Output = #ty> #(+ ::embrio_async::Captures<#lifetimes>)* + 'future
+                -> impl ::core::future::Future<Output = #ty> #(+ ::embrio_async::Captures<#lifetimes>)* + ::embrio_async::PinnableFuture<FutureOutput = #ty> + 'future
             },
         }).unwrap();
     }

--- a/embrio-async/macros/src/lib.rs
+++ b/embrio-async/macros/src/lib.rs
@@ -232,7 +232,7 @@ impl syn::visit_mut::VisitMut for ExpandPinned {
         let tokens: Expr = parse_quote!(#tokens);
         *node = syn::parse_quote! {
             #(#attrs)*
-            ::embrio_async::#pin_trait::pin(#tokens, pin!(::core::default::Default::default()))
+            ::embrio_async::#pin_trait::pin(#tokens, pin!(unsafe { ::embrio_async::UnsafeDefault::unsafe_default() }))
         };
     }
 }

--- a/embrio-async/src/lib.rs
+++ b/embrio-async/src/lib.rs
@@ -8,11 +8,12 @@
 use core::{
     future::Future,
     marker::PhantomPinned,
-    mem,
+    mem::{self, MaybeUninit},
     ops::{Generator, GeneratorState},
     pin::Pin,
     ptr,
     task::{self, Poll},
+    hint::unreachable_unchecked,
 };
 use futures_core::stream::Stream;
 
@@ -53,8 +54,7 @@ impl<T> IsPoll for Poll<T> {
 // returned by `C`.
 enum FutureImplState<C, G> {
     NotStarted(C),
-    Started(G),
-    Invalid,
+    Started(FutureImpl<G>),
 }
 
 // An `async` block is tranformed into a `FutureImpl`, where initially `C` is a closure of the form
@@ -76,20 +76,146 @@ enum FutureImplState<C, G> {
 // when `FutureImpl` is first `poll`ed (or `poll_next`ed), `FutureImpl`'s `state` field goes from
 // `FutureImplState::NotStarted(C)` to `FutureImplState::Started(G)` and the generator executes
 // till the first yield point.
-struct FutureImpl<C, G> {
+
+struct FutureImpl<G> {
     context: *mut task::Context<'static>,
-    state: FutureImplState<C, G>,
+    state: MaybeUninit<G>,
     _pinned: PhantomPinned,
 }
 
-unsafe impl<C, G> Send for FutureImpl<C, G>
+impl<G> Default for FutureImpl<G> {
+    fn default() -> Self {
+        Self::uninit()
+    }
+}
+
+impl<G> Drop for FutureImpl<G> {
+    fn drop(&mut self) {
+        if self.is_pinned() {
+            unsafe {
+                ptr::drop_in_place(self.state.as_mut_ptr());
+            }
+        }
+    }
+}
+
+impl<G> FutureImpl<G> {
+    fn uninit() -> Self {
+        FutureImpl {
+            context: ptr::null_mut(),
+            state: MaybeUninit::uninit(),
+            _pinned: PhantomPinned,
+        }
+    }
+
+    fn init<C: FnOnce(UnsafeContextRef) -> G>(self: Pin<&mut Self>, c: C) -> Pin<&mut PinnedFutureImpl<G>> {
+        // calling this multiple times will leak a generator
+        let this = unsafe { Pin::get_unchecked_mut(self) };
+        this.state = MaybeUninit::new(c(UnsafeContextRef(&mut this.context)));
+        this.context = 1 as usize as *mut _; // marker value used to indicate state is valid and can be dropped
+        unsafe { this.pinned_unchecked() }
+    }
+
+    fn is_pinned(&self) -> bool {
+        !self.context.is_null()
+    }
+
+    fn pinned(&mut self) -> Option<Pin<&mut PinnedFutureImpl<G>>> {
+        match self.is_pinned() {
+            true => Some(unsafe { self.pinned_unchecked() }),
+            false => None,
+        }
+    }
+
+    unsafe fn pinned_unchecked(&mut self) -> Pin<&mut PinnedFutureImpl<G>> {
+        Pin::new_unchecked(mem::transmute(self))
+    }
+}
+
+#[repr(transparent)]
+struct PinnedFutureImpl<G> {
+    inner: FutureImpl<G>,
+}
+
+impl<G> PinnedFutureImpl<G> {
+    fn state(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Pin<&mut G> {
+        unsafe {
+            let this = Pin::get_unchecked_mut(self);
+            this.inner.context = loosen_context_lifetime(cx);
+            Pin::new_unchecked(&mut *this.inner.state.as_mut_ptr())
+        }
+    }
+}
+
+unsafe impl<G> Send for FutureImpl<G>
 where
-    C: Send,
     G: Send,
 {
 }
 
-impl<C, G> Future for FutureImpl<C, G>
+impl<G> Future for PinnedFutureImpl<G>
+where
+    G: Generator<Yield = Poll<!>>,
+{
+    type Output = G::Return;
+
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        match self.state(cx).resume() {
+            GeneratorState::Yielded(Poll::Pending) => Poll::Pending,
+            GeneratorState::Complete(x) => Poll::Ready(x),
+        }
+    }
+}
+
+impl<G> Stream for PinnedFutureImpl<G>
+where
+    G: Generator<Return = ()>,
+    G::Yield: IsPoll,
+{
+    type Item = <G::Yield as IsPoll>::Ready;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match self.state(cx).resume() {
+            GeneratorState::Yielded(x) => x.into_poll().map(Some),
+            GeneratorState::Complete(()) => Poll::Ready(None),
+        }
+    }
+}
+
+impl<C, G> FutureImplState<C, G> where
+    C: FnOnce(UnsafeContextRef) -> G,
+{
+    fn started(self: Pin<&mut Self>) -> Pin<&mut PinnedFutureImpl<G>> {
+        let this = unsafe { Pin::get_unchecked_mut(self) };
+        match this {
+            FutureImplState::Started(started) => match started.pinned() {
+                Some(pinned) => pinned,
+                None => panic!("poisoned"),
+            },
+            FutureImplState::NotStarted(..) => {
+                let (c, pinned) = unsafe {
+                    let c = mem::replace(this, FutureImplState::Started(FutureImpl::uninit()));
+                    (match c {
+                        FutureImplState::NotStarted(c) => c,
+                        _ => unreachable_unchecked(),
+                    }, match this {
+                        FutureImplState::Started(pinned) => Pin::new_unchecked(pinned),
+                        _ => unreachable_unchecked(),
+                    })
+                };
+                pinned.init(c)
+            },
+        }
+    }
+}
+
+impl<C, G> Future for FutureImplState<C, G>
 where
     C: FnOnce(UnsafeContextRef) -> G,
     G: Generator<Yield = Poll<!>>,
@@ -109,28 +235,11 @@ where
         // create it until we have observed ourselves in a pin so we know we
         // can't have moved between creating the pointer and the generator ever
         // using the pointer so it is safe to dereference).
-        let this = unsafe { Pin::get_unchecked_mut(self) };
-        if let FutureImplState::Started(g) = &mut this.state {
-            unsafe {
-                this.context = loosen_context_lifetime(cx);
-                match Pin::new_unchecked(g).resume() {
-                    GeneratorState::Yielded(Poll::Pending) => Poll::Pending,
-                    GeneratorState::Complete(x) => Poll::Ready(x),
-                }
-            }
-        } else if let FutureImplState::NotStarted(c) =
-            mem::replace(&mut this.state, FutureImplState::Invalid)
-        {
-            let gen = c(UnsafeContextRef(&mut this.context));
-            this.state = FutureImplState::Started(gen);
-            unsafe { Pin::new_unchecked(this) }.poll(cx)
-        } else {
-            panic!("reached invalid state")
-        }
+        self.started().poll(cx)
     }
 }
 
-impl<C, G> Stream for FutureImpl<C, G>
+impl<C, G> Stream for FutureImplState<C, G>
 where
     C: FnOnce(UnsafeContextRef) -> G,
     G: Generator<Return = ()>,
@@ -143,24 +252,7 @@ where
         cx: &mut task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         // Safety: See `impl Future for FutureImpl`
-        let this = unsafe { Pin::get_unchecked_mut(self) };
-        if let FutureImplState::Started(g) = &mut this.state {
-            unsafe {
-                this.context = loosen_context_lifetime(cx);
-                match Pin::new_unchecked(g).resume() {
-                    GeneratorState::Yielded(x) => x.into_poll().map(Some),
-                    GeneratorState::Complete(()) => Poll::Ready(None),
-                }
-            }
-        } else if let FutureImplState::NotStarted(c) =
-            mem::replace(&mut this.state, FutureImplState::Invalid)
-        {
-            let gen = c(UnsafeContextRef(&mut this.context));
-            this.state = FutureImplState::Started(gen);
-            unsafe { Pin::new_unchecked(this) }.poll_next(cx)
-        } else {
-            panic!("reached invalid state")
-        }
+        self.started().poll_next(cx)
     }
 }
 
@@ -190,11 +282,7 @@ where
     C: FnOnce(UnsafeContextRef) -> G,
     G: Generator<Yield = Poll<!>>,
 {
-    FutureImpl {
-        context: ptr::null_mut(),
-        state: FutureImplState::NotStarted(c),
-        _pinned: PhantomPinned,
-    }
+    FutureImplState::NotStarted(c)
 }
 
 pub unsafe fn make_stream<T, C, G>(c: C) -> impl Stream<Item = T>
@@ -202,11 +290,7 @@ where
     C: FnOnce(UnsafeContextRef) -> G,
     G: Generator<Yield = Poll<T>, Return = ()>,
 {
-    FutureImpl {
-        context: ptr::null_mut(),
-        state: FutureImplState::NotStarted(c),
-        _pinned: PhantomPinned,
-    }
+    FutureImplState::NotStarted(c)
 }
 
 fn _check_send() -> impl Future<Output = u8> + Send {

--- a/embrio-async/tests/smoke.rs
+++ b/embrio-async/tests/smoke.rs
@@ -22,6 +22,15 @@ fn test_async_block() {
     assert_eq!(block_on(f2), 5);
 }
 
+#[embrio_async]
+#[test]
+fn test_async_pinned() {
+    let f = pinned!(async { 5usize });
+
+    let f2 = pinned!(async { f.await });
+    assert_eq!(block_on(f2), 5);
+}
+
 #[test]
 #[ergo_pin]
 #[embrio_async]
@@ -32,6 +41,16 @@ fn smoke_stream() {
     });
     assert_eq!(block_on(stream.next()), Some(5));
     assert_eq!(block_on(stream.next()), Some(6));
+    assert_eq!(block_on(stream.next()), None);
+}
+
+#[test]
+#[embrio_async]
+fn smoke_stream_pinned() {
+    let mut stream = pinned_stream!(async {
+        yield async { 5 }.pending_once().await;
+    });
+    assert_eq!(block_on(stream.next()), Some(5));
     assert_eq!(block_on(stream.next()), None);
 }
 


### PR DESCRIPTION
So this is all very WIP and I'm mostly posting for feedback at the moment. The commits/messages iterate through the changes/improvements, but basically the motivations here are:
- Looking into the overhead of generators/futures/async fns led me to try and improve the codegen/types slightly. These are small things but saving 100 bytes or so for every future constructed tends to be significant when working with flash-constrained devices, it helps the optimizer, etc.
- The current `Invalid` state indicates a poisoned future, which is overhead considering it's an extra enum variant that can introduce checks/assertions/panics in `poll()`. However, this state can only be observed if the call into the `c` generator constructor fails. Given that `make_future()` is unsafe, it can simply be made part of the API contract that the closure passed to it must not panic (ideally it does zero significant work and simply returns the generator after moving the pinned context reference into it). This is also an easy(?) assertion to make simply because the macro already knows and controls what it calls `make_future()` with.
- We can make static guarantees that a future is no longer in the `NotStarted` state once a future has been pinned/initialized by using a newtype reference. Though this requires the call site to opt-in via custom traits, it means properly pinned futures do not need to check the enum discriminator for every (or any) single `poll()` call.

And a few notes on the wip-ness:
- I need to shuffle around / reevaluate the safety assertions. I think my conjectures are true, but I'm mostly just experimenting right now.
- The explicit pin interface is awkward. I made it take `self` by move because that allows it to be safe/typechecked but that means you need separate storage variable for the pinned data to then be placed in. I plan on cleaning this up with a newtype/typestate style wrapper that reuses the existing enum but just narrows the variant with the newtype reference.
    - Also the way in which I use `ergo_pin` is rather awkward, I'd like to look into moving the transform elsewhere or bringing it into the macro. Just throwing it into the await expansion is an option but also less flexible compared to how `ergo_pin` lets you bind it properly via `let`.