### PR TITLE
Async sink take 2

### DIFF
--- a/embrio-async/Cargo.toml
+++ b/embrio-async/Cargo.toml
@@ -4,9 +4,14 @@ version = "0.1.0"
 authors = ["Wim Looman <wim@nemo157.com>"]
 edition = "2018"
 
+[features]
+default = ["sink"]
+sink = ["futures-sink"]
+
 [dependencies]
 embrio-async-macros = { path = "macros" }
 futures-core = { version = "0.3.1", default-features = false }
+futures-sink = { version = "0.3.0", default-features = false, optional = true }
 pin-project-lite = "0.1.4"
 
 [dev-dependencies]

--- a/embrio-async/macros/Cargo.toml
+++ b/embrio-async/macros/Cargo.toml
@@ -10,4 +10,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.6"
 quote = "1.0.2"
-syn = { version = "1.0.11", features = ["full", "visit", "visit-mut", "parsing"] }
+syn = { version = "1.0.11", features = ["full", "visit", "visit-mut", "parsing", "extra-traits"] }

--- a/embrio-async/macros/src/lib.rs
+++ b/embrio-async/macros/src/lib.rs
@@ -78,6 +78,7 @@ fn async_block(expr_async: &mut syn::ExprAsync) -> Expr {
     let block = &mut expr_async.block;
     let mv = &expr_async.capture;
     syn::visit_mut::visit_block_mut(&mut ExpandAwait, block);
+    let stmts = &block.stmts;
     let arg = Ident::new("_embrio_async_context_argument", Span::call_site());
     let tokens = quote!({
         // Safety: We trust users not to come here, see that argument name we
@@ -87,7 +88,7 @@ fn async_block(expr_async: &mut syn::ExprAsync) -> Expr {
         unsafe {
             ::embrio_async::make_future(static #mv |mut #arg: ::embrio_async::UnsafeContextRef| {
                 if false { #arg = yield ::core::task::Poll::Pending; }
-                #block
+                #(#stmts)*
             })
         }
     });

--- a/embrio-async/macros/src/lib.rs
+++ b/embrio-async/macros/src/lib.rs
@@ -230,9 +230,10 @@ fn async_sink_block(closure: &mut syn::ExprClosure) -> Expr {
     );
     // Pretty hacky, use the type of an unnamed input as the item type and the
     // return type as the result type to derive the error from
+    let underscore_pat: Pat = syn::parse_quote!(_);
     let input_ty = match closure.inputs.first() {
         Some(pat) => match pat {
-            Pat::Type(PatType { pat, ty, .. }) if &*pat == &syn::parse_quote!(_) => {
+            Pat::Type(PatType { pat, ty, .. }) if **pat == underscore_pat => {
                 ty.clone()
             }
             _ => panic!("a sink argument must be `_: T` where `T` is the input item type"),

--- a/embrio-async/macros/src/lib.rs
+++ b/embrio-async/macros/src/lib.rs
@@ -8,9 +8,9 @@ use quote::quote;
 
 use syn::{
     parse_macro_input, visit::Visit, visit_mut::VisitMut, Block, Expr,
-    ExprYield, Generics, Ident, ItemFn, Lifetime, LifetimeDef, Receiver,
-    ReturnType, TypeBareFn, TypeImplTrait, TypeParam, TypeParamBound,
-    TypeReference, Pat, PatIdent,
+    ExprYield, Generics, Ident, ItemFn, Lifetime, LifetimeDef, Pat, PatType,
+    Receiver, ReturnType, TypeBareFn, TypeImplTrait, TypeParam, TypeParamBound,
+    TypeReference,
 };
 
 // A `.await` expression is transformed into,
@@ -32,8 +32,7 @@ use syn::{
 //         yield ::core::task::Poll::Pending;
 //     }
 // }
-fn await_impl(input: &Expr) -> Expr {
-    let arg = Ident::new("_embrio_async_context_argument", Span::call_site());
+fn await_impl(context_arg: &Ident, input: &Expr) -> Expr {
     let expr = quote!({
         let mut pinned = #input;
         loop {
@@ -44,12 +43,12 @@ fn await_impl(input: &Expr) -> Expr {
             // safe for reasons explained in the embrio-async safety notes.
             let polled = unsafe {
                 let pin = ::core::pin::Pin::new_unchecked(&mut pinned);
-                ::core::future::Future::poll(pin, #arg.get_context())
+                ::core::future::Future::poll(pin, #context_arg.get_context())
             };
             if let ::core::task::Poll::Ready(x) = polled {
                 break x;
             }
-            #arg = yield ::core::task::Poll::Pending;
+            #context_arg = yield ::core::task::Poll::Pending;
         }
     });
     syn::parse2(expr).unwrap()
@@ -75,19 +74,20 @@ fn await_impl(input: &Expr) -> Expr {
 // `static` in `static move || { ... }` means that the generator may hold self-references across
 // yield points.
 fn async_block(expr_async: &mut syn::ExprAsync) -> Expr {
+    let context_arg =
+        Ident::new("_embrio_async_context_argument", Span::call_site());
     let block = &mut expr_async.block;
     let mv = &expr_async.capture;
-    syn::visit_mut::visit_block_mut(&mut ExpandAwait, block);
+    syn::visit_mut::visit_block_mut(&mut ExpandAwait(&context_arg), block);
     let stmts = &block.stmts;
-    let arg = Ident::new("_embrio_async_context_argument", Span::call_site());
     let tokens = quote!({
         // Safety: We trust users not to come here, see that argument name we
         // generated above and use that in their code to break our other safety
         // guarantees. Our use of it in await! is safe because of reasons
         // probably described in the embrio-async safety notes.
         unsafe {
-            ::embrio_async::make_future(static #mv |mut #arg: ::embrio_async::UnsafeContextRef| {
-                if false { #arg = yield ::core::task::Poll::Pending; }
+            ::embrio_async::make_future(static #mv |mut #context_arg: ::embrio_async::UnsafeContextRef| {
+                if false { #context_arg = yield ::core::task::Poll::Pending; }
                 #(#stmts)*
             })
         }
@@ -125,7 +125,7 @@ fn async_stream_block(expr_async: &mut syn::ExprAsync) -> Expr {
                 .take()
                 .unwrap_or_else(|| syn::parse_str("()").unwrap());
             node.expr = Some(Box::new(
-                syn::parse2(quote!(::core::task::Poll::Ready(#expr))).unwrap(),
+                syn::parse_quote!(::core::task::Poll::Ready(#expr)),
             ));
         }
         fn visit_expr_mut(&mut self, i: &mut Expr) {
@@ -137,25 +137,123 @@ fn async_stream_block(expr_async: &mut syn::ExprAsync) -> Expr {
         }
     }
 
+    let context_arg =
+        Ident::new("_embrio_async_context_argument", Span::call_site());
     let mut block = &mut expr_async.block;
     let capture = &expr_async.capture;
     syn::visit_mut::VisitMut::visit_block_mut(&mut ReplaceYields, &mut block);
-    syn::visit_mut::VisitMut::visit_block_mut(&mut ExpandAwait, &mut block);
-    let arg = Ident::new("_embrio_async_context_argument", Span::call_site());
+    syn::visit_mut::VisitMut::visit_block_mut(
+        &mut ExpandAwait(&context_arg),
+        &mut block,
+    );
     let stream = quote!({
         // Safety: We trust users not to come here, see that argument name we
         // generated above and use that in their code to break our other safety
         // guarantees. Our use of it in await! is safe because of reasons
         // probably described in the embrio-async safety notes.
         unsafe {
-            ::embrio_async::make_stream(static #capture |mut #arg: ::embrio_async::UnsafeContextRef| {
-                if false { #arg = yield ::core::task::Poll::Pending; }
+            ::embrio_async::make_stream(static #capture |mut #context_arg: ::embrio_async::UnsafeContextRef| {
+                if false { #context_arg = yield ::core::task::Poll::Pending; }
                 #block
             })
         }
     });
 
     syn::parse2(stream).unwrap()
+}
+
+// When an `async` closure contains a `yield` keyword, then its transformed into a sink.
+fn async_sink_block(closure: &mut syn::ExprClosure) -> Expr {
+    struct ReplaceYieldsInSink<'a>(&'a Ident);
+
+    impl syn::visit_mut::VisitMut for ReplaceYieldsInSink<'_> {
+        fn visit_expr_mut(&mut self, i: &mut Expr) {
+            let unit: Expr = syn::parse_quote!(());
+            match i {
+                Expr::Closure(_) => {
+                    // Don't descend into closures
+                }
+                Expr::Yield(node) => {
+                    assert!(
+                        node.expr.is_none()
+                            || node.expr.as_deref() == Some(&unit),
+                        "Cannot yield values in a sink"
+                    );
+                    let context_arg = self.0;
+                    *i = syn::parse_quote!({
+                        let mut maybe_item = ::core::option::Option::None;
+                        loop {
+                            match maybe_item {
+                                ::core::option::Option::Some(item) => break item,
+                                ::core::option::Option::None => {
+                                    #context_arg = match #context_arg {
+                                        ::embrio_async::SinkContext::StartSend(item) => {
+                                            maybe_item = ::core::option::Option::Some(::core::option::Option::Some(item));
+                                            yield ::embrio_async::SinkResult::Accepted
+                                        }
+                                        ::embrio_async::SinkContext::Flush(cx) => {
+                                            yield ::embrio_async::SinkResult::Idle
+                                        }
+                                        ::embrio_async::SinkContext::Close(cx) => {
+                                            maybe_item = ::core::option::Option::Some(::core::option::Option::None);
+                                            ::embrio_async::SinkContext::Close(cx)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    });
+                }
+                i => {
+                    syn::visit_mut::visit_expr_mut(self, i);
+                }
+            }
+        }
+    }
+
+    let context_arg =
+        Ident::new("_embrio_async_sink_context_argument", Span::call_site());
+    let mut body = &mut closure.body;
+    let capture = &closure.capture;
+    assert!(
+        closure.inputs.len() < 2,
+        "a sink must take either 0 or 1 arguments"
+    );
+    // Pretty hacky, use the type of an unnamed input as the item type and the
+    // return type as the error type
+    let input_ty = match closure.inputs.first() {
+        Some(pat) => match pat {
+            Pat::Type(PatType { pat, ty, .. }) if &*pat == &syn::parse_quote!(_) => {
+                ty.clone()
+            }
+            _ => panic!("a sink argument must be `_: T` where `T` is the input item type"),
+        }
+        None => syn::parse_quote!(_),
+    };
+    let error_ty = match &closure.output {
+        ReturnType::Default => panic!("a sink return type representing the error must be given as inference doesn't work"),
+        ReturnType::Type(_, ty) => ty.clone(),
+    };
+    syn::visit_mut::VisitMut::visit_expr_mut(
+        &mut ReplaceYieldsInSink(&context_arg),
+        &mut body,
+    );
+    syn::visit_mut::VisitMut::visit_expr_mut(
+        &mut ExpandAwaitInSink(&context_arg),
+        &mut body,
+    );
+    syn::parse_quote!({
+        // Safety: We trust users not to come here, see that argument name we
+        // generated above and use that in their code to break our other safety
+        // guarantees. Our use of it in await! is safe because of reasons
+        // probably described in the embrio-async safety notes.
+        unsafe {
+            ::embrio_async::make_sink(static #capture |mut #context_arg: ::embrio_async::SinkContext<#input_ty>| {
+                if false { #context_arg = yield ::embrio_async::SinkResult::Idle; }
+                ::core::result::Result::Ok::<_, #error_ty>(#body)
+            })
+        }
+    })
 }
 
 #[proc_macro_attribute]
@@ -181,9 +279,9 @@ fn async_fn_impl(mut item: ItemFn) -> TokenStream {
     quote!(#item)
 }
 
-struct ExpandAwait;
+struct ExpandAwait<'a>(&'a Ident);
 
-impl syn::visit_mut::VisitMut for ExpandAwait {
+impl syn::visit_mut::VisitMut for ExpandAwait<'_> {
     fn visit_expr_mut(&mut self, node: &mut syn::Expr) {
         syn::visit_mut::visit_expr_mut(self, node);
         let base = match node {
@@ -191,7 +289,65 @@ impl syn::visit_mut::VisitMut for ExpandAwait {
             _ => return,
         };
 
-        *node = await_impl(base);
+        *node = await_impl(self.0, base);
+    }
+}
+
+struct ExpandAwaitInSink<'a>(&'a Ident);
+
+impl syn::visit_mut::VisitMut for ExpandAwaitInSink<'_> {
+    fn visit_expr_mut(&mut self, node: &mut syn::Expr) {
+        syn::visit_mut::visit_expr_mut(self, node);
+
+        let input = match node {
+            syn::Expr::Await(syn::ExprAwait { base, .. }) => &*base,
+            _ => return,
+        };
+
+        let context_arg = self.0;
+        *node = syn::parse_quote!({
+            enum MaybeDone<F, T> { NotDone(F), Done(::core::option::Option<T>) }
+            let mut maybe_future = MaybeDone::NotDone(#input);
+            loop {
+                // Safety: We trust users to only call this from within an
+                // async_block created generator, they are static generators so must
+                // be immovable in memory, so creating a pinned reference into a
+                // generator-local is safe. de-referencing the argument pointer is
+                // safe for reasons explained in the embrio-async safety notes.
+                match &mut maybe_future {
+                    MaybeDone::NotDone(future) => {
+                        #context_arg = match #context_arg {
+                            ::embrio_async::SinkContext::StartSend(item) => {
+                                yield ::embrio_async::SinkResult::NotReady
+                            }
+                            | ::embrio_async::SinkContext::Flush(mut cx) => {
+                                let polled = unsafe {
+                                    let pin = ::core::pin::Pin::new_unchecked(future);
+                                    ::core::future::Future::poll(pin, cx.get_context())
+                                };
+                                if let ::core::task::Poll::Ready(x) = polled {
+                                    maybe_future = MaybeDone::Done(::core::option::Option::Some(x));
+                                }
+                                ::embrio_async::SinkContext::Flush(cx)
+                            }
+                            | ::embrio_async::SinkContext::Close(mut cx) => {
+                                let polled = unsafe {
+                                    let pin = ::core::pin::Pin::new_unchecked(future);
+                                    ::core::future::Future::poll(pin, cx.get_context())
+                                };
+                                if let ::core::task::Poll::Ready(x) = polled {
+                                    maybe_future = MaybeDone::Done(::core::option::Option::Some(x));
+                                }
+                                ::embrio_async::SinkContext::Close(cx)
+                            }
+                        };
+                    }
+                    MaybeDone::Done(e) => {
+                        break e.take().unwrap();
+                    }
+                }
+            }
+        });
     }
 }
 
@@ -200,51 +356,32 @@ struct AsyncBlockTransform;
 
 impl VisitMut for AsyncBlockTransform {
     fn visit_expr_mut(&mut self, i: &mut Expr) {
-        let yield_pat = Pat::Ident(PatIdent {
-            attrs: Vec::new(),
-            by_ref: None,
-            mutability: None,
-            ident: Ident::new("yield", Span::call_site()),
-            subpat: None,
-        });
         syn::visit_mut::visit_expr_mut(self, i);
-        let fut = match i {
+
+        let expr_contains_yield = contains_yield(i);
+        match i {
             Expr::Async(expr_async) => {
-                if contains_yield(&expr_async.block) {
-                    async_stream_block(expr_async)
+                if expr_contains_yield {
+                    *i = async_stream_block(expr_async);
                 } else {
-                    async_block(expr_async)
+                    *i = async_block(expr_async);
                 }
             }
             Expr::Closure(closure) => {
                 if closure.asyncness.is_some() {
-                    if let Some(Pat::Ident(PatIdent { ident, .. })) = closure.inputs.first() {
-                        if ident == "yield" {
-                            dbg!("async yield");
-                            panic!()
-                        } else {
-                            eprintln!("async non-yield pat: {:?}", ident);
-                            panic!()
-                        }
+                    if contains_yield(&closure.body) {
+                        *i = async_sink_block(closure);
                     } else {
-                        dbg!("async non-pat");
-                        panic!()
+                        panic!("async closures are unsupported: {:?}", closure)
                     }
-                } else {
-                    dbg!(closure);
-                    panic!()
                 }
             }
-            _ => {
-                return;
-            }
-        };
-
-        *i = fut;
+            _ => (),
+        }
     }
 }
 
-fn contains_yield(block: &Block) -> bool {
+fn contains_yield(block: &Expr) -> bool {
     struct ContainsYield(bool);
 
     impl<'a> Visit<'a> for ContainsYield {
@@ -262,7 +399,7 @@ fn contains_yield(block: &Block) -> bool {
     }
 
     let mut visitor = ContainsYield(false);
-    syn::visit::visit_block(&mut visitor, block);
+    syn::visit::visit_expr(&mut visitor, block);
     visitor.0
 }
 

--- a/embrio-async/tests/no-prelude-leak.rs
+++ b/embrio-async/tests/no-prelude-leak.rs
@@ -42,3 +42,68 @@ fn smoke_stream() {
         ::core::assert_eq!(::futures::executor::block_on(future), 11);
     }
 }
+
+#[test]
+fn smoke_sink() {
+    let future = async {
+        let mut sum = 0;
+        {
+            let slow = async move |i| i;
+            let stream = ::embrio_async::async_stream_block! {
+                yield async { slow(5) }.await;
+                yield async { slow(6) }.await;
+            };
+            let sink = ::embrio_async::async_sink_block! {
+                while let ::core::option::Option::Some(future) =
+                    ::embrio_async::await_input!()
+                {
+                    sum += future.await;
+                }
+                sum += 7;
+            };
+            ::pin_utils::pin_mut!(sink);
+            let stream = ::futures::stream::StreamExt::map(
+                stream,
+                ::core::result::Result::Ok,
+            );
+            ::futures::stream::StreamExt::forward(stream, sink).await.unwrap();
+        }
+        sum
+    };
+    {
+        use ::std::panic;
+        ::std::assert_eq!(::futures::executor::block_on(future), 18);
+    }
+}
+
+#[test]
+fn smoke_sink_typed() {
+    let future = async {
+        let mut sum = 0;
+        {
+            let stream = ::embrio_async::async_stream_block! {
+                yield 5;
+                yield 6;
+            };
+            let sink = ::embrio_async::async_sink_block!(u32 -> {
+                while let ::core::option::Option::Some(value) =
+                    ::embrio_async::await_input!()
+                {
+                    sum += value;
+                }
+                sum += 7;
+            });
+            ::pin_utils::pin_mut!(sink);
+            let stream = ::futures::stream::StreamExt::map(
+                stream,
+                ::core::result::Result::Ok,
+            );
+            ::futures::stream::StreamExt::forward(stream, sink).await.unwrap();
+        }
+        sum
+    };
+    {
+        use ::std::panic;
+        ::std::assert_eq!(::futures::executor::block_on(future), 18);
+    }
+}

--- a/embrio-async/tests/no-prelude-leak.rs
+++ b/embrio-async/tests/no-prelude-leak.rs
@@ -55,11 +55,12 @@ fn smoke_sink() {
                 yield async { slow(5) }.await;
                 yield async { slow(6) }.await;
             };
-            let sink = async || -> ! {
+            let sink = async || -> ::core::result::Result<(), !> {
                 while let ::core::option::Option::Some(future) = yield () {
                     sum += future.await;
                 }
                 sum += 7;
+                ::core::result::Result::Ok(())
             };
             ::pin_utils::pin_mut!(sink);
             let stream = ::futures::stream::StreamExt::map(
@@ -88,11 +89,12 @@ fn smoke_sink_typed() {
                 yield ::core::result::Result::Ok(5);
                 yield ::core::result::Result::Ok(6);
             };
-            let sink = async |_: ::core::result::Result<u32, u64>| -> u64 {
+            let sink = async |_: ::core::result::Result<u32, u64>| -> ::core::result::Result<(), u64> {
                 while let ::core::option::Option::Some(value) = yield () {
                     sum += value?;
                 }
                 sum += 7;
+                ::core::result::Result::Ok(())
             };
             ::pin_utils::pin_mut!(sink);
             let stream = ::futures::stream::StreamExt::map(


### PR DESCRIPTION
replaces #4 

```rust
let sink = async |_: Result<u32, u64>| -> Result<(), u64> {
    while let Some(value) = (yield) {
        sum += value?;
    }
    sum += 7;
    Ok(())
};
```

not great syntax. `yield` is used to read in a new item, and you need the explicit `()` on the `yield` in a `while let` loop as otherwise the block becomes part of the yield (or `(yield)`). The type of the unnamed argument is the type of the input items (normally unnecessary, and the argument itself doesn't need to be there, inference will take care of it) and the return type is used to derive the type of `Sink::Error`.